### PR TITLE
Get arnesi to build with ASDF 3.3

### DIFF
--- a/arnesi.asd
+++ b/arnesi.asd
@@ -1,21 +1,13 @@
 ;;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :it.bese.arnesi.system)
-    (defpackage :it.bese.arnesi.system
-      (:documentation "ASDF System package for ARNESI.")
-      (:use :common-lisp :asdf))))
-
-(in-package :it.bese.arnesi.system)
-
-(defsystem :arnesi
+(defsystem "arnesi"
   :components ((:static-file "arnesi.asd")
-               (:module :src
+               (:module "src"
                 :components ((:file "accumulation" :depends-on ("packages" "one-liners"))
                              (:file "asdf" :depends-on ("packages" "io"))
                              (:file "csv" :depends-on ("packages" "string"))
                              (:file "compat" :depends-on ("packages"))
-                             (:module :call-cc
+                             (:module "call-cc"
                               :components ((:file "interpreter")
                                            (:file "handlers")
                                            (:file "apply")
@@ -54,11 +46,11 @@
 			     (:file "unwalk" :depends-on ("packages" "walk"))
                              (:file "vector" :depends-on ("packages" "flow-control"))
                              (:file "walk" :depends-on ("packages" "list" "mopp" "lexenv" "one-liners")))))
-  :properties ((:features "v1.4.0" "v1.4.1" "v1.4.2" "cc-interpreter"
-                          "join-strings-return-value" "getenv")))
+  ;; :properties ((:features "v1.4.0" "v1.4.1" "v1.4.2" "cc-interpreter" "join-strings-return-value" "getenv"))
+  :in-order-to ((test-op (test-op "arnesi/test"))))
 
-(defsystem :arnesi.test
-  :components ((:module :t
+(defsystem "arnesi/test"
+  :components ((:module "t"
 		:components ((:file "accumulation" :depends-on ("suite"))
                              (:file "call-cc" :depends-on ("suite"))
                              (:file "http" :depends-on ("suite"))
@@ -74,25 +66,17 @@
 			     (:file "walk" :depends-on ("suite"))
 			     (:file "csv" :depends-on ("suite"))
                              (:file "suite"))))
-  :depends-on (:arnesi :FiveAM)
-  :in-order-to ((compile-op (load-op :arnesi))))
+  :depends-on ("arnesi" "fiveam")
+  :perform (test-op (o c) (symbol-call :it.bese.FiveAM :run!) :it.bese.arnesi))
 
-(defsystem :arnesi.cl-ppcre-extras
-  :components ((:module :src
+(defsystem "arnesi/cl-ppcre-extras"
+  :components ((:module "src"
                 :components ((:file "cl-ppcre-extras"))))
-  :depends-on (:cl-ppcre :arnesi))
+  :depends-on ("cl-ppcre" "arnesi"))
 
-(defsystem :arnesi.slime-extras
-  :components ((:module :src :components ((:file "slime-extras"))))
-  :depends-on (:arnesi :swank))
-
-(defmethod perform ((op asdf:test-op) (system (eql (find-system :arnesi))))
-  (asdf:oos 'asdf:load-op :arnesi.test)
-  (funcall (intern (string :run!) (string :it.bese.FiveAM))
-           :it.bese.arnesi))
-
-(defmethod operation-done-p ((op test-op) (system (eql (find-system :arnesi))))
-  nil)
+(defsystem "arnesi/slime-extras"
+  :components ((:module "src" :components ((:file "slime-extras"))))
+  :depends-on ("arnesi" "swank"))
 
 ;;;; * Introduction
 

--- a/src/asdf.lisp
+++ b/src/asdf.lisp
@@ -32,25 +32,10 @@
 ;;;; NB: Unlike the CLEAN-OP this is experimental (its now to have
 ;;;; problems on multiple systems with non-trivial dependencies).
 
-(defun make-single-fasl (system-name
-                         &key (op (make-instance 'asdf:load-op))
-                              output-file)
-  (let* ((system (asdf:find-system system-name))
-         (steps (asdf::traverse op system))
-         (output-file (or output-file
-                          (compile-file-pathname
-                           (make-pathname
-                            :name (asdf:component-name system)
-                            :defaults (asdf:component-pathname system)))))
-         (*buffer* (make-array 4096 :element-type '(unsigned-byte 8)
-                                    :adjustable t)))
-    (declare (special *buffer*))
-    (with-output-to-file (*fasl* output-file
-                          :if-exists :error
-                          :element-type '(unsigned-byte 8))
-      (declare (special *fasl*))
-      (dolist (s steps)
-        (process-step (car s) (cdr s) output-file)))))
+(defun make-single-fasl (system-name &key output-file)
+  (asdf:operate 'asdf:compile-bundle-op system-name)
+  (when output-file
+    (uiop:copy-file (first (asdf:input-files 'asdf:compile-bundle-op system-name)) output-file)))
 
 (defgeneric process-step (op comp output-file))
 

--- a/t/suite.lisp
+++ b/t/suite.lisp
@@ -7,7 +7,8 @@
         :it.bese.arnesi
         :it.bese.FiveAM))
 
-(unless (5am:get-test :it.bese)
-  (5am:def-suite :it.bese))
+(eval-when (:load-toplevel :compile-toplevel :execute)
+  (unless (5am:get-test :it.bese)
+    (5am:def-suite :it.bese)))
 
 (5am:def-suite :it.bese.arnesi :in :it.bese)


### PR DESCRIPTION
Stop using the deprecated ASDF:TRAVERSE.
Instead use COMPILE-BUNDLE-OP from ASDF 3.1.2.

Use proper secondary system names, and modern .asd conventions.

PS: the tests fail to compile call-cc because they error out on DECLARE.