### PR TITLE
Remove getter from k-for-free-setq

### DIFF
--- a/src/call-cc/handlers.lisp
+++ b/src/call-cc/handlers.lisp
@@ -231,7 +231,7 @@
   (let ((exp (macroexpand var)))
     (if (eq var exp)
         (setf (symbol-value var) value)
-        (multiple-value-bind (dummies vals new setter getter)
+        (multiple-value-bind (dummies vals new setter)
             (get-setf-expansion var)
           (funcall (compile nil
                             `(lambda ()


### PR DESCRIPTION
It's bound but not used,
so remove it.